### PR TITLE
 Add bucket property `node_confirms` for physical diversity

### DIFF
--- a/docs/Node-Diversity.md
+++ b/docs/Node-Diversity.md
@@ -1,39 +1,123 @@
 # Node Diversity
 ## Background
-At NHS Digital, we use Riak as part of the Spine system that stores patient information and data, and which is vital to the efficient running of the UK NHS technology systems that support the healthcare process. The data stored includes patient demographics data, prescriptions, clinical summary records, and much more.
 
-It is important that this system is available, but also that the storage of data is durable.  Once the system receives and acknowledges a reliable message from a partner system, we guarantee that we will not lose this message, and that it will be processed.  As a distributed database Riak helps us keep this guarantee, and helps us to ensure once we have processed such a message, we don't lose the patient data or the changes made to it.
+At NHS Digital, we use Riak as part of the Spine system that stores
+patient information and data, and which is vital to the efficient
+running of the UK NHS technology systems that support the healthcare
+process. The data stored includes patient demographics data,
+prescriptions, clinical summary records, and much more.
 
-An important feature of a distributed database is that this data is written to more than one node, to help us ensure that data isn't lost due to individual hardware failures. To achieve this, the Spine system has historically used the primary write option in Riak, setting pw=2. The claim algorithm which distributes partition responsibility around the nodes will guarantee that primary vnodes are on different nodes.  The pw setting is used therefore as a proxy for physical diversity guarantees.  With this condition applied, the durability of writes can be guaranteed even when individual nodes in the cluster fail - and acknowledgements can safely be issued once database writes have completed.
+It is important that this system is available, but also that the
+storage of data is durable.  Once the system receives and acknowledges
+a reliable message from a partner system, we guarantee that we will
+not lose this message, and that it will be processed.  As a
+distributed database Riak helps us keep this guarantee, and helps us
+to ensure once we have processed such a message, we don't lose the
+patient data or the changes made to it.
+
+An important feature of a distributed database is that this data is
+written to more than one node, to help us ensure that data isn't lost
+due to individual hardware failures. To achieve this, the Spine system
+has historically used the primary write option in Riak, setting
+pw=2. The claim algorithm which distributes partition responsibility
+around the nodes will guarantee that primary vnodes are on different
+nodes.  The pw setting is used therefore as a proxy for physical
+diversity guarantees.  With this condition applied, the durability of
+writes can be guaranteed even when individual nodes in the cluster
+fail - and acknowledgements can safely be issued once database writes
+have completed.
 
 ## The Problem
-The problem starts when a second node fails. This means that pw=2 cannot be satisfied for all writes, as the preflist (the list of vnodes currently supporting writes for that partition of the keyspace) for some writes may now contain a single primary node and two fallback nodes. In this case, since pw=2 has not been satisfied, the cluster begins to reject writes.
 
-This is not a problem for availability of the Spine system, as the system runs on two separate sites with reconciliation and automated fail-over between them, so service is maintained seamlessly by the switch of service to the alternative site.  It would though, be easier and smoother for us if we could handle this scenario without having to do a site-switch.
+The problem starts when a second node fails. This means that pw=2
+cannot be satisfied for all writes, as the preflist (the list of
+vnodes currently supporting writes for that partition of the keyspace)
+for some writes may now contain a single primary node and two fallback
+nodes. In this case, since pw=2 has not been satisfied, the cluster
+begins to reject writes.
 
-Since each of our database clusters have 7-9 nodes, when the claim algorithm works efficiently, fallback nodes are almost certainly also physically diverse nodes to the remaining primary nodes.  That is to say, the writes that are being failed when two nodes are down, almost certainly have been written to physically diverse nodes.  The writes are not being failed as the desired condition (of physical diversity) has not been met, it is just that the ring-based promise within the pw option cannot confirm that it has been met.
+This is not a problem for availability of the Spine system, as the
+system runs on two separate sites with reconciliation and automated
+fail-over between them, so service is maintained seamlessly by the
+switch of service to the alternative site.  It would though, be easier
+and smoother for us if we could handle this scenario without having to
+do a site-switch.
+
+Since each of our database clusters have 7-9 nodes, when the claim
+algorithm works efficiently, fallback nodes are almost certainly also
+physically diverse nodes to the remaining primary nodes.  That is to
+say, the writes that are being failed when two nodes are down, almost
+certainly have been written to physically diverse nodes.  The writes
+are not being failed as the desired condition (of physical diversity)
+has not been met, it is just that the ring-based promise within the pw
+option cannot confirm that it has been met.
 
 # The Solution
-The solution to the problem is to more directly tie configuration options over diversity to the physical layout of the system at run-time, not the abstract concept of the ring.  It would be helpful if Riak requests could be configured to directly confirm if they have achieved a desired level of node diversity.
+
+The solution to the problem is to more directly tie configuration
+options over diversity to the physical layout of the system at
+run-time, not the abstract concept of the ring.  It would be helpful
+if Riak requests could be configured to directly confirm if they have
+achieved a desired level of node diversity.
 
 ## Implementation
-When riak receives a 'put', it starts up a [riak_kv_put_fsm](../src/riak_kv_put_fsm.erl) (finite state machine). This [prepares](../src/riak_kv_put_fsm.erl#L277) and then [validates](../src/riak_kv_put_fsm.erl#L386) the options, then calls any [precommit hooks](../src/riak_kv_put_fsm.erl#L501), before [executing a put to the local vnode](../src/riak_kv_put_fsm.erl#L542) in the preflist, which becomes the co-ordinating node. This then [waits for the local vnode response](../src/riak_kv_put_fsm.erl#L564) before [executing the put request remotely](../src/riak_kv_put_fsm.erl#L598) on the two remaining nodes in the preflist.
 
-The fsm then [waits for the remote vnode responses](../src/riak_kv_put_fsm.erl#L628), and as it receives responses, it [adds these results](../src/riak_kv_put_core.erl#L88) and checks whether [enough](../src/riak_kv_put_core.erl#L111) results have been collected to satisfy the bucket properties such as _'dw'_ and _'pw'_. 
+When riak receives a 'put', it starts up a
+[riak_kv_put_fsm](../src/riak_kv_put_fsm.erl) (finite state
+machine). This [prepares](../src/riak_kv_put_fsm.erl#L277) and then
+[validates](../src/riak_kv_put_fsm.erl#L386) the options, then calls
+any [precommit hooks](../src/riak_kv_put_fsm.erl#L501), before
+[executing a put to the local vnode](../src/riak_kv_put_fsm.erl#L542)
+in the preflist, which becomes the co-ordinating node. This then
+[waits for the local vnode response](../src/riak_kv_put_fsm.erl#L564)
+before
+[executing the put request remotely](../src/riak_kv_put_fsm.erl#L598)
+on the two remaining nodes in the preflist.
 
-This stage has now been enhanced through this branch.  When analysing the responses, Riak will now [count the number of different nodes](../src/riak_kv_put_core.erl#L246) from which results have been returned.  The finite state machine can now be required to wait for a minimum number of confirmations from different nodes, whilst also ensuring all other configured options are satisfied.
+The fsm then
+[waits for the remote vnode responses](../src/riak_kv_put_fsm.erl#L628),
+and as it receives responses, it
+[adds these results](../src/riak_kv_put_core.erl#L88) and checks
+whether [enough](../src/riak_kv_put_core.erl#L111) results have been
+collected to satisfy the bucket properties such as _'dw'_ and _'pw'_.
 
-Once all options are satisfied, the [response is returned](../src/riak_kv_put_fsm.erl#L766), [post commit hooks](../src/riak_kv_put_fsm.erl#L666) are called and the [fsm finishes](../src/riak_kv_put_fsm.erl#L683).
+This stage has now been enhanced through this branch.  When analysing
+the responses, Riak will now
+[count the number of different nodes](../src/riak_kv_put_core.erl#L246)
+from which results have been returned.  The finite state machine can
+now be required to wait for a minimum number of confirmations from
+different nodes, whilst also ensuring all other configured options are
+satisfied.
+
+Once all options are satisfied, the
+[response is returned](../src/riak_kv_put_fsm.erl#L766),
+[post commit hooks](../src/riak_kv_put_fsm.erl#L666) are called and
+the [fsm finishes](../src/riak_kv_put_fsm.erl#L683).
 
 ### What's in an option name?
-The hardest question is what to call the option? _'pd'_ (physical diversity) was considered, but the option only provides node diversity and cannot guarantee physical diversity (see Limitations). _'nd'_ was considered but both 'n' and 'd' are already specific terms within Riak and may lead to confusion.
 
-Terms such as _'node_diversity'_ sound like a boolean option, rather than expecting an integer number.
+The hardest question is what to call the option? _'pd'_ (physical
+diversity) was considered, but the option only provides node diversity
+and cannot guarantee physical diversity (see Limitations). _'nd'_ was
+considered but both 'n' and 'd' are already specific terms within Riak
+and may lead to confusion.
 
-Hence we have decided to call this option _'node_confirms'_,as this is the number of different nodes we require to confirm their write has been successful. We chose to break from the 'traditional' two letter options such as pw and dw as they are vnode based options, whereas this is a node based option, and it is also more descriptive.
+Terms such as _'node_diversity'_ sound like a boolean option, rather
+than expecting an integer number.
+
+Hence we have decided to call this option _'node_confirms'_,as this is
+the number of different nodes we require to confirm their write has
+been successful. We chose to break from the 'traditional' two letter
+options such as pw and dw as they are vnode based options, whereas
+this is a node based option, and it is also more descriptive.
 
 ## Testing
-Testing is done by adding unit tests for the count mechanisms, and by creating a [riak_test](https://github.com/ramensen/riak_test/blob/rs-physical-promises/tests/node_confirms_vs_pw.erl) that does the following:
+
+Testing is done by adding unit tests for the count mechanisms, and by
+creating a
+[riak_test](https://github.com/ramensen/riak_test/blob/rs-physical-promises/tests/node_confirms_vs_pw.erl)
+that does the following:
+
 * Start a 5 node cluster
 * Get a preflist for a key
 * Stop 2 primary nodes for that key
@@ -46,6 +130,14 @@ Testing is done by adding unit tests for the count mechanisms, and by creating a
 * Check a node_confirms=3 write fails
 
 ## Limitations
-While this goes a way to providing physical diversity, there are limitations to this solution, and it is only a start. For instance, there is no concept of rack awareness and rack diversity. If the nodes are based in the cloud, there is no easy way to determine whether the backend database for a node is stored on the same physical storage device as that for another node, nor is there any awareness of availability zones.
 
-Solving these issues would require more engineering effort, and for the purposes of NHS Riak, is not currently required.
+While this goes a way to providing physical diversity, there are
+limitations to this solution, and it is only a start. For instance,
+there is no concept of rack awareness and rack diversity. If the nodes
+are based in the cloud, there is no easy way to determine whether the
+backend database for a node is stored on the same physical storage
+device as that for another node, nor is there any awareness of
+availability zones.
+
+Solving these issues would require more engineering effort, and for
+the purposes of NHS Riak, is not currently required.

--- a/docs/Node-Diversity.md
+++ b/docs/Node-Diversity.md
@@ -1,0 +1,51 @@
+# Node Diversity
+## Background
+At NHS Digital, we use Riak as part of the Spine system that stores patient information and data, and which is vital to the efficient running of the UK NHS technology systems that support the healthcare process. The data stored includes patient demographics data, prescriptions, clinical summary records, and much more.
+
+It is important that this system is available, but also that the storage of data is durable.  Once the system receives and acknowledges a reliable message from a partner system, we guarantee that we will not lose this message, and that it will be processed.  As a distributed database Riak helps us keep this guarantee, and helps us to ensure once we have processed such a message, we don't lose the patient data or the changes made to it.
+
+An important feature of a distributed database is that this data is written to more than one node, to help us ensure that data isn't lost due to individual hardware failures. To achieve this, the Spine system has historically used the primary write option in Riak, setting pw=2. The claim algorithm which distributes partition responsibility around the nodes will guarantee that primary vnodes are on different nodes.  The pw setting is used therefore as a proxy for physical diversity guarantees.  With this condition applied, the durability of writes can be guaranteed even when individual nodes in the cluster fail - and acknowledgements can safely be issued once database writes have completed.
+
+## The Problem
+The problem starts when a second node fails. This means that pw=2 cannot be satisfied for all writes, as the preflist (the list of vnodes currently supporting writes for that partition of the keyspace) for some writes may now contain a single primary node and two fallback nodes. In this case, since pw=2 has not been satisfied, the cluster begins to reject writes.
+
+This is not a problem for availability of the Spine system, as the system runs on two separate sites with reconciliation and automated fail-over between them, so service is maintained seamlessly by the switch of service to the alternative site.  It would though, be easier and smoother for us if we could handle this scenario without having to do a site-switch.
+
+Since each of our database clusters have 7-9 nodes, when the claim algorithm works efficiently, fallback nodes are almost certainly also physically diverse nodes to the remaining primary nodes.  That is to say, the writes that are being failed when two nodes are down, almost certainly have been written to physically diverse nodes.  The writes are not being failed as the desired condition (of physical diversity) has not been met, it is just that the ring-based promise within the pw option cannot confirm that it has been met.
+
+# The Solution
+The solution to the problem is to more directly tie configuration options over diversity to the physical layout of the system at run-time, not the abstract concept of the ring.  It would be helpful if Riak requests could be configured to directly confirm if they have achieved a desired level of node diversity.
+
+## Implementation
+When riak receives a 'put', it starts up a [riak_kv_put_fsm](../src/riak_kv_put_fsm.erl) (finite state machine). This [prepares](../src/riak_kv_put_fsm.erl#L277) and then [validates](../src/riak_kv_put_fsm.erl#L386) the options, then calls any [precommit hooks](../src/riak_kv_put_fsm.erl#L501), before [executing a put to the local vnode](../src/riak_kv_put_fsm.erl#L542) in the preflist, which becomes the co-ordinating node. This then [waits for the local vnode response](../src/riak_kv_put_fsm.erl#L564) before [executing the put request remotely](../src/riak_kv_put_fsm.erl#L598) on the two remaining nodes in the preflist.
+
+The fsm then [waits for the remote vnode responses](../src/riak_kv_put_fsm.erl#L628), and as it receives responses, it [adds these results](../src/riak_kv_put_core.erl#L88) and checks whether [enough](../src/riak_kv_put_core.erl#L111) results have been collected to satisfy the bucket properties such as _'dw'_ and _'pw'_. 
+
+This stage has now been enhanced through this branch.  When analysing the responses, Riak will now [count the number of different nodes](../src/riak_kv_put_core.erl#L246) from which results have been returned.  The finite state machine can now be required to wait for a minimum number of confirmations from different nodes, whilst also ensuring all other configured options are satisfied.
+
+Once all options are satisfied, the [response is returned](../src/riak_kv_put_fsm.erl#L766), [post commit hooks](../src/riak_kv_put_fsm.erl#L666) are called and the [fsm finishes](../src/riak_kv_put_fsm.erl#L683).
+
+### What's in an option name?
+The hardest question is what to call the option? _'pd'_ (physical diversity) was considered, but the option only provides node diversity and cannot guarantee physical diversity (see Limitations). _'nd'_ was considered but both 'n' and 'd' are already specific terms within Riak and may lead to confusion.
+
+Terms such as _'node_diversity'_ sound like a boolean option, rather than expecting an integer number.
+
+Hence we have decided to call this option _'node_confirms'_,as this is the number of different nodes we require to confirm their write has been successful. We chose to break from the 'traditional' two letter options such as pw and dw as they are vnode based options, whereas this is a node based option, and it is also more descriptive.
+
+## Testing
+Testing is done by adding unit tests for the count mechanisms, and by creating a [riak_test](https://github.com/ramensen/riak_test/blob/rs-physical-promises/tests/node_confirms_vs_pw.erl) that does the following:
+* Start a 5 node cluster
+* Get a preflist for a key
+* Stop 2 primary nodes for that key
+* Wait for a new preflist confirming there are 2 fallbacks
+* Check a pw=2 write fails
+* Check a node_confirms=2 write succeeds
+* Check a node_confirms=4 write is rejected as a bad value (n_val=3!)
+* Stop another node in the preflist (now only 2 nodes remain up)
+* Wait for a new preflist
+* Check a node_confirms=3 write fails
+
+## Limitations
+While this goes a way to providing physical diversity, there are limitations to this solution, and it is only a start. For instance, there is no concept of rack awareness and rack diversity. If the nodes are based in the cloud, there is no easy way to determine whether the backend database for a node is stored on the same physical storage device as that for another node, nor is there any awareness of availability zones.
+
+Solving these issues would require more engineering effort, and for the purposes of NHS Riak, is not currently required.

--- a/docs/Node-Diversity.md
+++ b/docs/Node-Diversity.md
@@ -63,36 +63,43 @@ achieved a desired level of node diversity.
 ## Implementation
 
 When riak receives a 'put', it starts up a
-[riak_kv_put_fsm](../src/riak_kv_put_fsm.erl) (finite state
-machine). This [prepares](../src/riak_kv_put_fsm.erl#L277) and then
-[validates](../src/riak_kv_put_fsm.erl#L386) the options, then calls
-any [precommit hooks](../src/riak_kv_put_fsm.erl#L501), before
-[executing a put to the local vnode](../src/riak_kv_put_fsm.erl#L542)
-in the preflist, which becomes the co-ordinating node. This then
-[waits for the local vnode response](../src/riak_kv_put_fsm.erl#L564)
+[riak_kv_put_fsm](https://github.com/nhs-riak/riak_kv/blob/6c6ce819af2b6f73476f44611212ad755c5a2833/src/riak_kv_put_fsm.erl)
+(finite state machine). This
+[prepares](https://github.com/nhs-riak/riak_kv/blob/6c6ce819af2b6f73476f44611212ad755c5a2833/src/riak_kv_put_fsm.erl#L277)
+and then
+[validates](https://github.com/nhs-riak/riak_kv/blob/6c6ce819af2b6f73476f44611212ad755c5a2833/src/riak_kv_put_fsm.erl#L386)
+the options, then calls any
+[precommit hooks](https://github.com/nhs-riak/riak_kv/blob/6c6ce819af2b6f73476f44611212ad755c5a2833/src/riak_kv_put_fsm.erl#L501),
 before
-[executing the put request remotely](../src/riak_kv_put_fsm.erl#L598)
+[executing a put to the local vnode](https://github.com/nhs-riak/riak_kv/blob/6c6ce819af2b6f73476f44611212ad755c5a2833/src/riak_kv_put_fsm.erl#L542)
+in the preflist, which becomes the co-ordinating node. This then
+[waits for the local vnode response](https://github.com/nhs-riak/riak_kv/blob/6c6ce819af2b6f73476f44611212ad755c5a2833/src/riak_kv_put_fsm.erl#L564)
+before
+[executing the put request remotely](https://github.com/nhs-riak/riak_kv/blob/6c6ce819af2b6f73476f44611212ad755c5a2833/src/riak_kv_put_fsm.erl#L598)
 on the two remaining nodes in the preflist.
 
 The fsm then
-[waits for the remote vnode responses](../src/riak_kv_put_fsm.erl#L628),
+[waits for the remote vnode responses](https://github.com/nhs-riak/riak_kv/blob/6c6ce819af2b6f73476f44611212ad755c5a2833/src/riak_kv_put_fsm.erl#L628),
 and as it receives responses, it
-[adds these results](../src/riak_kv_put_core.erl#L88) and checks
-whether [enough](../src/riak_kv_put_core.erl#L111) results have been
-collected to satisfy the bucket properties such as _'dw'_ and _'pw'_.
+[adds these results](https://github.com/nhs-riak/riak_kv/blob/6c6ce819af2b6f73476f44611212ad755c5a2833/src/riak_kv_put_core.erl#L88)
+and checks whether
+[enough](https://github.com/nhs-riak/riak_kv/blob/6c6ce819af2b6f73476f44611212ad755c5a2833/src/riak_kv_put_core.erl#L111)
+results have been collected to satisfy the bucket properties such as
+`dw` and `pw`.
 
-This stage has now been enhanced through this branch.  When analysing
-the responses, Riak will now
-[count the number of different nodes](../src/riak_kv_put_core.erl#L246)
+This stage has now been enhanced through the addition of
+`node_confirms`.  When analysing the responses, Riak will now
+[count the number of different nodes](https://github.com/nhs-riak/riak_kv/blob/6c6ce819af2b6f73476f44611212ad755c5a2833/src/riak_kv_put_core.erl#L246)
 from which results have been returned.  The finite state machine can
 now be required to wait for a minimum number of confirmations from
 different nodes, whilst also ensuring all other configured options are
 satisfied.
 
 Once all options are satisfied, the
-[response is returned](../src/riak_kv_put_fsm.erl#L766),
-[post commit hooks](../src/riak_kv_put_fsm.erl#L666) are called and
-the [fsm finishes](../src/riak_kv_put_fsm.erl#L683).
+[response is returned](https://github.com/nhs-riak/riak_kv/blob/6c6ce819af2b6f73476f44611212ad755c5a2833/src/riak_kv_put_fsm.erl#L766),
+[post commit hooks](https://github.com/nhs-riak/riak_kv/blob/6c6ce819af2b6f73476f44611212ad755c5a2833/src/riak_kv_put_fsm.erl#L666)
+are called and the
+[fsm finishes](https://github.com/nhs-riak/riak_kv/blob/6c6ce819af2b6f73476f44611212ad755c5a2833/src/riak_kv_put_fsm.erl#L683).
 
 ### What's in an option name?
 
@@ -115,7 +122,7 @@ this is a node based option, and it is also more descriptive.
 
 Testing is done by adding unit tests for the count mechanisms, and by
 creating a
-[riak_test](https://github.com/ramensen/riak_test/blob/rs-physical-promises/tests/node_confirms_vs_pw.erl)
+[riak_test](https://github.com/ramensen/riak_test/blob/aa088b8931c7361a4e2956a4930126e9954f3b4e/tests/node_confirms_vs_pw.erl)
 that does the following:
 
 * Start a 5 node cluster

--- a/src/riak_kv_app.erl
+++ b/src/riak_kv_app.erl
@@ -93,6 +93,7 @@ start(_Type, _StartArgs) ->
        {r, quorum},
        {w, quorum},
        {pw, 0},
+       {node_confirms, 0},
        {dw, quorum},
        {rw, quorum},
        {basic_quorum, false},

--- a/src/riak_kv_bucket.erl
+++ b/src/riak_kv_bucket.erl
@@ -291,6 +291,7 @@ validate([{QProp, MaybeQ}=Prop | T], ValidProps, Errors) when  QProp =:= r
     end;
 validate([{QProp, MaybeQ}=Prop | T], ValidProps, Errors) when QProp =:= dw
                                                               orelse QProp =:= pw
+                                                              orelse QProp =:= node_confirms
                                                               orelse QProp =:= pr ->
     case is_opt_quorum(MaybeQ) of
         true ->

--- a/src/riak_kv_put_core.erl
+++ b/src/riak_kv_put_core.erl
@@ -20,7 +20,7 @@
 %%
 %% -------------------------------------------------------------------
 -module(riak_kv_put_core).
--export([init/9, add_result/2, enough/1, response/1,
+-export([init/11, add_result/2, enough/1, response/1,
          final/1, result_shortcode/1, result_idx/1]).
 -export_type([putcore/0, result/0, reply/0]).
 
@@ -40,12 +40,14 @@
                  {error, notfound} |
                  {error, any()}.
 -type idxresult() :: {non_neg_integer(), result()}.
--type idx_type() :: [{non_neg_integer, 'primary' | 'fallback'}].
+-type idx_type() :: [{non_neg_integer(), 'primary' | 'fallback', node()}].
 -record(putcore, {n :: pos_integer(),
                   w :: non_neg_integer(),
                   dw :: non_neg_integer(),
                   pw :: non_neg_integer(),
+                  node_confirms :: non_neg_integer(),
                   pw_fail_threshold :: pos_integer(),
+                  node_confirms_fail_threshold :: pos_integer(),
                   dw_fail_threshold :: pos_integer(),
                   returnbody :: boolean(),
                   allowmult :: boolean(),
@@ -54,6 +56,7 @@
                   num_w = 0 :: non_neg_integer(),
                   num_dw = 0 :: non_neg_integer(),
                   num_pw = 0 :: non_neg_integer(),
+                  num_node_confirms = 0 :: non_neg_integer(),
                   num_fail = 0 :: non_neg_integer(),
                   idx_type :: idx_type() %% mapping of idx -> primary | fallback
                  }).
@@ -64,14 +67,17 @@
 %% ====================================================================
 
 %% Initialize a put and return an opaque put core context
--spec init(N::pos_integer(), W::non_neg_integer(), PW::non_neg_integer(),
-           DW::non_neg_integer(), PWFail::pos_integer(), DWFail::pos_integer(),
+-spec init(N::pos_integer(), W::non_neg_integer(),
+           PW::non_neg_integer(), NodeConfirms::non_neg_integer(),
+           DW::non_neg_integer(), PWFail::pos_integer(),
+           NodeConfirmsFail::pos_integer(), DWFail::pos_integer(),
            AllowMult::boolean(), ReturnBody::boolean(),
            IDXType::idx_type()) -> putcore().
-init(N, W, PW, DW, PWFailThreshold,
+init(N, W, PW, NodeConfirms, DW, PWFailThreshold, NodeConfirmsFailThreshold,
      DWFailThreshold, AllowMult, ReturnBody, IdxType) ->
-    #putcore{n = N, w = W, pw = PW, dw = DW,
+    #putcore{n = N, w = W, pw = PW, dw = DW, node_confirms = NodeConfirms,
              pw_fail_threshold = PWFailThreshold,
+             node_confirms_fail_threshold = NodeConfirmsFailThreshold,
              dw_fail_threshold = DWFailThreshold,
              allowmult = AllowMult,
              returnbody = ReturnBody,
@@ -85,12 +91,12 @@ add_result({w, Idx, _ReqId}, PutCore = #putcore{results = Results,
                     num_w = NumW + 1};
 add_result({dw, Idx, _ReqId}, PutCore = #putcore{results = Results,
                                                  num_dw = NumDW}) ->
-    num_pw(PutCore#putcore{results = [{Idx, {dw, undefined}} | Results],
-                    num_dw = NumDW + 1}, Idx);
+    num_node_confirms(num_pw(PutCore#putcore{results = [{Idx, {dw, undefined}} | Results],
+                    num_dw = NumDW + 1}, Idx));
 add_result({dw, Idx, ResObj, _ReqId}, PutCore = #putcore{results = Results,
                                                          num_dw = NumDW}) ->
-    num_pw(PutCore#putcore{results = [{Idx, {dw, ResObj}} | Results],
-                    num_dw = NumDW + 1}, Idx);
+    num_node_confirms(num_pw(PutCore#putcore{results = [{Idx, {dw, ResObj}} | Results],
+                    num_dw = NumDW + 1}, Idx));
 add_result({fail, Idx, _ReqId}, PutCore = #putcore{results = Results,
                                                    num_fail = NumFail}) ->
     PutCore#putcore{results = [{Idx, {error, undefined}} | Results],
@@ -102,12 +108,16 @@ add_result(_Other, PutCore = #putcore{num_fail = NumFail}) ->
 %% Check if enough results have been added to respond
 -spec enough(putcore()) -> boolean().
 %% The perfect world, all the quorum restrictions have been met.
-enough(#putcore{w = W, num_w = NumW, dw = DW, num_dw = NumDW, pw = PW, num_pw = NumPW}) when
-      NumW >= W, NumDW >= DW, NumPW >= PW ->
+enough(#putcore{w = W, num_w = NumW, dw = DW, num_dw = NumDW, pw = PW, num_pw = NumPW, node_confirms = NodeConfirms, num_node_confirms = NumNodeConfirms}) when
+      NumW >= W, NumDW >= DW, NumPW >= PW, NumNodeConfirms >= NodeConfirms ->
     true;
 %% Enough failures that we can't meet the PW restriction
 enough(#putcore{ num_fail = NumFail, pw_fail_threshold = PWFailThreshold}) when
       NumFail >= PWFailThreshold ->
+    true;
+%% Enough failures that we can't meet the NodeConfirms restriction
+enough(#putcore{ num_fail = NumFail, node_confirms_fail_threshold = NodeConfirmsFailThreshold}) when
+      NumFail >= NodeConfirmsFailThreshold ->
     true;
 %% Enough failures that we can't meet the DW restriction
 enough(#putcore{ num_fail = NumFail, dw_fail_threshold = DWFailThreshold}) when
@@ -117,14 +127,18 @@ enough(#putcore{ num_fail = NumFail, dw_fail_threshold = DWFailThreshold}) when
 enough(#putcore{n = N, num_dw = NumDW, num_fail = NumFail, pw = PW, num_pw = NumPW}) when
       NumDW + NumFail >= N, NumPW < PW ->
     true;
+%% We've received all DW responses but can't satisfy NodeConfirms
+enough(#putcore{n = N, num_dw = NumDW, num_fail = NumFail, node_confirms = NodeConfirms, num_node_confirms = NumNodeConfirms}) when
+      NumDW + NumFail >= N, NumNodeConfirms < NodeConfirms ->
+    true;
 enough(_PutCore) ->
     false.
 
 %% Get success/fail response once enough results received
 -spec response(putcore()) -> {reply(), putcore()}.
 %% Perfect world - all quora met
-response(PutCore = #putcore{w = W, num_w = NumW, dw = DW, num_dw = NumDW, pw = PW, num_pw = NumPW}) when
-      NumW >= W, NumDW >= DW, NumPW >= PW ->
+response(PutCore = #putcore{w = W, num_w = NumW, dw = DW, num_dw = NumDW, pw = PW, num_pw = NumPW, node_confirms = NodeConfirms, num_node_confirms = NumNodeConfirms}) when
+      NumW >= W, NumDW >= DW, NumPW >= PW, NumNodeConfirms >= NodeConfirms ->
     maybe_return_body(PutCore);
 %% Everything is ok, except we didn't meet PW
 response(PutCore = #putcore{w = W, num_w = NumW, dw = DW, num_dw = NumDW, pw = PW, num_pw = NumPW}) when
@@ -134,6 +148,14 @@ response(PutCore = #putcore{w = W, num_w = NumW, dw = DW, num_dw = NumDW, pw = P
 response(PutCore = #putcore{n = N, num_fail = NumFail, dw = DW, pw=PW, num_pw = NumPW}) when
       NumFail > N - PW, PW >= DW ->
     check_overload({error, {pw_val_unsatisfied, PW, NumPW}}, PutCore);
+%% Everything is ok, except we didn't meet NodeConfirms
+response(PutCore = #putcore{w = W, num_w = NumW, dw = DW, num_dw = NumDW, node_confirms = NodeConfirms, num_node_confirms = NumNodeConfirms}) when
+      NumW >= W, NumDW >= DW, NumNodeConfirms < NodeConfirms ->
+    check_overload({error, {node_confirms_val_unsatisfied, NodeConfirms, NumNodeConfirms}}, PutCore);
+%% Didn't make NodeConfirms, and NodeConfirms >= DW
+response(PutCore = #putcore{n = N, num_fail = NumFail, dw = DW, node_confirms=NodeConfirms, num_node_confirms = NumNodeConfirms}) when
+      NumFail > N - NodeConfirms, NodeConfirms >= DW ->
+    check_overload({error, {node_confirms_val_unsatisfied, NodeConfirms, NumNodeConfirms}}, PutCore);
 %% Didn't make DW and DW > PW
 response(PutCore = #putcore{n = N, num_fail = NumFail, dw = DW, num_dw = NumDW}) when
       NumFail > N - DW ->
@@ -193,7 +215,7 @@ maybe_return_body(PutCore = #putcore{returnbody = true}) ->
 is_primary_response(Idx, IdxType) ->
     case lists:keyfind(Idx, 1, IdxType) of
         false -> true;
-        {Idx, Status} -> Status == primary
+        {Idx, Status, _Node} -> Status == primary
     end.
 
 %% @private Increment PW, if appropriate
@@ -205,65 +227,132 @@ num_pw(PutCore = #putcore{num_pw=NumPW, idx_type=IdxType}, Idx) ->
             PutCore
     end.
 
+%% @private Calculate number of physically diverse partitions in results
+-spec count_diverse_nodes(IDXType::idx_type(), [idxresult()]) -> non_neg_integer().
+count_diverse_nodes(IdxType, Results) ->
+    DWrites = [Part || {Part, {dw, _}} <- Results ],
+    count_physically_diverse(IdxType, DWrites, []).
 
+-spec count_physically_diverse(IDXType::idx_type(), [non_neg_integer()], [node()]) -> non_neg_integer().
+count_physically_diverse(_IdxType, [], NodeAcc) ->
+    UniqueNodes = lists:usort(NodeAcc),
+    length(UniqueNodes);
+count_physically_diverse(IdxType, [DWPart | DWRest], NodeAcc) ->
+    {DWPart, _Type, Node} = lists:keyfind(DWPart, 1, IdxType),
+    count_physically_diverse(IdxType, DWRest, [Node | NodeAcc]).
+
+%% @private Return number of physically diverse partitions in results
+-spec num_node_confirms(putcore()) -> putcore().
+num_node_confirms(PutCore = #putcore{idx_type=IdxType, results=Results}) ->
+    Cdn = count_diverse_nodes(IdxType, Results),
+    PutCore#putcore{num_node_confirms=Cdn}.
 
 -ifdef(TEST).
 %% simple sanity tests
+diversity_test_() ->
+    [
+        {"Diversity",
+            fun() ->
+                    ?assertEqual(1, count_diverse_nodes(
+                                 [{1,primary,node1},
+                                  {2,primary,node2},
+                                  {3,fallback,node3}],
+                                 [{1, {dw, undefined}}])),
+                    ?assertEqual(2, count_diverse_nodes(
+                                 [{1,primary,node1},
+                                  {2,primary,node2},
+                                  {3,fallback,node3}],
+                                 [{1, {dw, undefined}},
+                                  {3, {dw, undefined}}])),
+                    ?assertEqual(1, count_diverse_nodes(
+                                 [{1,primary,node1},
+                                  {2,primary,node2},
+                                  {3,fallback,node3}],
+                                 [{3, {dw, undefined}},
+                                  {3, {dw, undefined}},
+                                  {1, w}])),
+                ok
+        end}
+    ].
+
 enough_test_() ->
     [
         {"Checking W",
             fun() ->
                     %% you can never fail W directly...
-                    ?assertEqual(false, enough(#putcore{n=3, w=3, dw=0, pw=0,
+                    ?assertEqual(false, enough(#putcore{n=3, w=3, dw=0, pw=0, node_confirms=0,
                                 dw_fail_threshold=4, pw_fail_threshold=4, num_w=1,
                                 num_dw=0, num_pw=0, num_fail=0})),
-                    ?assertEqual(false, enough(#putcore{n=3, w=3, dw=0, pw=0,
+                    ?assertEqual(false, enough(#putcore{n=3, w=3, dw=0, pw=0, node_confirms=0,
                                 dw_fail_threshold=4, pw_fail_threshold=4, num_w=2,
                                 num_dw=0, num_pw=0, num_fail=0})),
                     %% got enough Ws
-                    ?assertEqual(true, enough(#putcore{n=3, w=3, dw=0, pw=0,
+                    ?assertEqual(true, enough(#putcore{n=3, w=3, dw=0, pw=0, node_confirms=0,
                                 dw_fail_threshold=4, pw_fail_threshold=4, num_w=3,
                                 num_dw=0, num_pw=0, num_fail=0})),
                 ok
         end},
         {"Checking DW",
             fun() ->
-                    ?assertEqual(false, enough(#putcore{n=3, w=0, dw=3, pw=0,
+                    ?assertEqual(false, enough(#putcore{n=3, w=0, dw=3, pw=0, node_confirms=0,
                                 dw_fail_threshold=1, pw_fail_threshold=4, num_w=3,
                                 num_dw=1, num_pw=0, num_fail=0})),
-                    ?assertEqual(false, enough(#putcore{n=3, w=0, dw=3, pw=0,
+                    ?assertEqual(false, enough(#putcore{n=3, w=0, dw=3, pw=0, node_confirms=0,
                                 dw_fail_threshold=1, pw_fail_threshold=4, num_w=3,
                                 num_dw=2, num_pw=0, num_fail=0})),
                     %% got enough DWs
-                    ?assertEqual(true, enough(#putcore{n=3, w=0, dw=3, pw=0,
+                    ?assertEqual(true, enough(#putcore{n=3, w=0, dw=3, pw=0, node_confirms=0,
                                 dw_fail_threshold=1, pw_fail_threshold=4, num_w=3,
                                 num_dw=3, num_pw=0, num_fail=0})),
                     %% exceeded failure threshold
-                    ?assertEqual(true, enough(#putcore{n=3, w=0, dw=3, pw=0,
+                    ?assertEqual(true, enough(#putcore{n=3, w=0, dw=3, pw=0, node_confirms=0,
                                 dw_fail_threshold=1, pw_fail_threshold=4, num_w=3,
                                 num_dw=2, num_pw=0, num_fail=1})),
                 ok
         end},
         {"Checking PW",
             fun() ->
-                    ?assertEqual(false, enough(#putcore{n=3, w=0, dw=0, pw=3,
+                    ?assertEqual(false, enough(#putcore{n=3, w=0, dw=0, pw=3, node_confirms=0,
                                 dw_fail_threshold=4, pw_fail_threshold=1, num_w=3,
                                 num_dw=1, num_pw=1, num_fail=0})),
-                    ?assertEqual(false, enough(#putcore{n=3, w=0, dw=0, pw=3,
+                    ?assertEqual(false, enough(#putcore{n=3, w=0, dw=0, pw=3, node_confirms=0,
                                 dw_fail_threshold=4, pw_fail_threshold=1, num_w=3,
                                 num_dw=2, num_pw=2, num_fail=0})),
                     %% got enough PWs
-                    ?assertEqual(true, enough(#putcore{n=3, w=0, dw=0, pw=3,
+                    ?assertEqual(true, enough(#putcore{n=3, w=0, dw=0, pw=3, node_confirms=0,
                                 dw_fail_threshold=4, pw_fail_threshold=1, num_w=3,
                                 num_dw=3, num_pw=3, num_fail=0})),
                     %% exceeded failure threshold
-                    ?assertEqual(true, enough(#putcore{n=3, w=0, dw=0, pw=3,
+                    ?assertEqual(true, enough(#putcore{n=3, w=0, dw=0, pw=3, node_confirms=0,
                                 dw_fail_threshold=4, pw_fail_threshold=1, num_w=3,
                                 num_dw=2, num_pw=2, num_fail=1})),
                     %% can never satisfy PW
-                    ?assertEqual(true, enough(#putcore{n=3, w=0, dw=0, pw=3,
+                    ?assertEqual(true, enough(#putcore{n=3, w=0, dw=0, pw=3, node_confirms=0,
                                 dw_fail_threshold=4, pw_fail_threshold=1, num_w=3,
                                 num_dw=3, num_pw=2, num_fail=0})),
+
+                ok
+        end},
+        {"Checking NodeConfirms",
+            fun() ->
+                    ?assertEqual(false, enough(#putcore{n=3, w=0, dw=0, pw=0, node_confirms=3,
+                                dw_fail_threshold=4, node_confirms_fail_threshold=1, num_w=3,
+                                num_dw=1, num_node_confirms=1, num_fail=0})),
+                    ?assertEqual(false, enough(#putcore{n=3, w=0, dw=0, pw=0, node_confirms=3,
+                                dw_fail_threshold=4, node_confirms_fail_threshold=1, num_w=3,
+                                num_dw=2, num_node_confirms=2, num_fail=0})),
+                    %% got enough NodeConfirmss
+                    ?assertEqual(true, enough(#putcore{n=3, w=0, dw=0, pw=0, node_confirms=3,
+                                dw_fail_threshold=4, node_confirms_fail_threshold=1, num_w=3,
+                                num_dw=3, num_node_confirms=3, num_fail=0})),
+                    %% exceeded failure threshold
+                    ?assertEqual(true, enough(#putcore{n=3, w=0, dw=0, pw=0, node_confirms=3,
+                                dw_fail_threshold=4, node_confirms_fail_threshold=1, num_w=3,
+                                num_dw=2, num_node_confirms=2, num_fail=1})),
+                    %% can never satisfy NodeConfirms
+                    ?assertEqual(true, enough(#putcore{n=3, w=0, dw=0, pw=0, node_confirms=3,
+                                dw_fail_threshold=4, node_confirms_fail_threshold=1, num_w=3,
+                                num_dw=3, num_node_confirms=2, num_fail=0})),
 
                 ok
         end}
@@ -274,7 +363,7 @@ response_test_() ->
         {"Requirements met",
             fun() ->
                     ?assertMatch({ok, _},
-                        response(#putcore{n=3, w=1, dw=3, pw=2,
+                        response(#putcore{n=3, w=1, dw=3, pw=2, node_confirms=0,
                                 dw_fail_threshold=1, pw_fail_threshold=2, num_w=3,
                                 num_dw=3, num_pw=2, num_fail=0,
                                 returnbody=false})),
@@ -283,7 +372,7 @@ response_test_() ->
         {"DW val unsatisfied",
             fun() ->
                     ?assertMatch({{error, {dw_val_unsatisfied, 3, 2}}, _},
-                        response(#putcore{n=3, w=0, dw=3, pw=0,
+                        response(#putcore{n=3, w=0, dw=3, pw=0, node_confirms=0,
                                 dw_fail_threshold=1, pw_fail_threshold=4, num_w=3,
                                 num_dw=2, num_pw=0, num_fail=1})),
                     %% can never satify PW or DW and PW >= DW
@@ -296,18 +385,35 @@ response_test_() ->
         {"PW val unsatisfied",
             fun() ->
                     ?assertMatch({{error, {pw_val_unsatisfied, 3, 2}}, _},
-                        response(#putcore{n=3, w=0, dw=0, pw=3,
+                        response(#putcore{n=3, w=0, dw=0, pw=3, node_confirms=0,
                                 dw_fail_threshold=4, pw_fail_threshold=1, num_w=3,
                                 num_dw=2, num_pw=2, num_fail=1})),
                     ?assertMatch({{error, {pw_val_unsatisfied, 3, 1}}, _},
-                        response(#putcore{n=3, w=0, dw=0, pw=3,
+                        response(#putcore{n=3, w=0, dw=0, pw=3, node_confirms=0,
                                 dw_fail_threshold=4, pw_fail_threshold=1, num_w=3,
                                 num_dw=3, num_pw=1, num_fail=0})),
                     %% can never satify PW or DW and PW >= DW
                     ?assertMatch({{error, {pw_val_unsatisfied, 3, 2}}, _},
-                        response(#putcore{n=3, w=0, dw=3, pw=3,
+                        response(#putcore{n=3, w=0, dw=3, pw=3, node_confirms=0,
                                 dw_fail_threshold=1, pw_fail_threshold=1, num_w=3,
                                 num_dw=2, num_pw=2, num_fail=1})),
+                    ok
+            end},
+        {"NodeConfirms val unsatisfied",
+            fun() ->
+                    ?assertMatch({{error, {node_confirms_val_unsatisfied, 3, 2}}, _},
+                        response(#putcore{n=3, w=0, dw=0, pw=0, node_confirms=3,
+                                dw_fail_threshold=4, node_confirms_fail_threshold=1, num_w=3,
+                                num_dw=2, num_node_confirms=2, num_fail=1})),
+                    ?assertMatch({{error, {node_confirms_val_unsatisfied, 3, 1}}, _},
+                        response(#putcore{n=3, w=0, dw=0, pw=0, node_confirms=3,
+                                dw_fail_threshold=4, node_confirms_fail_threshold=1, num_w=3,
+                                num_dw=3, num_node_confirms=1, num_fail=0})),
+                    %% can never satify PW or DW and PW >= DW
+                    ?assertMatch({{error, {node_confirms_val_unsatisfied, 3, 2}}, _},
+                        response(#putcore{n=3, w=0, dw=3, pw=0, node_confirms=3,
+                                dw_fail_threshold=1, node_confirms_fail_threshold=1, num_w=3,
+                                num_dw=2, num_node_confirms=2, num_fail=1})),
                     ok
             end}
 

--- a/src/riak_kv_put_fsm.erl
+++ b/src/riak_kv_put_fsm.erl
@@ -459,9 +459,6 @@ validate(timeout, StateData0 = #state{from = {raw, ReqId, _Pid},
                         end
                 end,
             PutCore = riak_kv_put_core:init(N, W, PW, NodeConfirms, DW,
-                                            N-PW+1,  % cannot ever get PW replies
-                                            N-NodeConfirms+1,  % cannot ever get NodeConfirms replies
-                                            N-DW+1,  % cannot ever get DW replies
                                             AllowMult,
                                             ReturnBody,
                                             IdxType),

--- a/src/riak_kv_wm_counter.erl
+++ b/src/riak_kv_wm_counter.erl
@@ -57,7 +57,7 @@
 %%                              `r' quorum if true. Default is the bucket default, if absent.</dd>
 %%    </dl>
 %%
-%%   == Quorum values (r/pr/w/pw/dw) ==
+%%   == Quorum values (r/pr/w/pw/node_confirms/dw) ==
 %%     <dl>
 %%       <dt>default</dt><dd>Whatever the bucket default is. This is the value used
 %%                          for any absent value.</dd>
@@ -98,6 +98,7 @@
               rw,           %% integer() - rw-value for deletes
               pr,           %% integer() - number of primary nodes required in preflist on read
               pw,           %% integer() - number of primary nodes required in preflist on write
+              node_confirms,%% integer() - number of physical nodes required in preflist on write
               basic_quorum, %% boolean() - whether to use basic_quorum
               notfound_ok,  %% boolean() - whether to treat notfounds as successes
               prefix,       %% string() - prefix for resource uris
@@ -236,6 +237,7 @@ malformed_rw_params(RD, Ctx) ->
                  {#ctx.w, "w", "default"},
                  {#ctx.dw, "dw", "default"},
                  {#ctx.pw, "pw", "default"},
+                 {#ctx.node_confirms, "node_confirms", "default"},
                  {#ctx.pr, "pr", "default"}]),
     lists:foldl(fun malformed_boolean_param/2,
                 Res,
@@ -306,7 +308,7 @@ accept_doc_body(RD, Ctx=#ctx{bucket=B, key=K, client=C,
         true ->
             Doc = riak_kv_crdt:new(B, K, ?V1_COUNTER_TYPE),
             Options = [{counter_op, CounterOp}] ++ return_value(RD),
-            case C:put(Doc, [{w, Ctx#ctx.w}, {dw, Ctx#ctx.dw}, {pw, Ctx#ctx.pw},
+            case C:put(Doc, [{w, Ctx#ctx.w}, {dw, Ctx#ctx.dw}, {pw, Ctx#ctx.pw}, {node_confirms, Ctx#ctx.node_confirms},
                              {timeout, 60000}, {retry_put_coordinator_failure, false} |
                                    Options]) of
                 {error, Reason} ->
@@ -374,7 +376,7 @@ handle_common_error(Reason, RD, Ctx) ->
                         RD)),
                 Ctx};
         {error, {n_val_violation, N}} ->
-            Msg = io_lib:format("Specified w/dw/pw values invalid for bucket"
+            Msg = io_lib:format("Specified w/dw/pw/node_confirms values invalid for bucket"
                 " n value of ~p~n", [N]),
             {{halt, 400}, wrq:append_to_response_body(Msg, RD), Ctx};
         {error, allow_mult_false} ->
@@ -406,6 +408,10 @@ handle_common_error(Reason, RD, Ctx) ->
                 Ctx};
         {error, {pw_val_unsatisfied, Requested, Returned}} ->
             Msg = io_lib:format("PW-value unsatisfied: ~p/~p~n", [Returned,
+                    Requested]),
+            {{halt, 503}, wrq:append_to_response_body(Msg, RD), Ctx};
+        {error, {node_confirms_val_unsatisfied, Requested, Returned}} ->
+            Msg = io_lib:format("node_confirms-value unsatisfied: ~p/~p~n", [Returned,
                     Requested]),
             {{halt, 503}, wrq:append_to_response_body(Msg, RD), Ctx};
         {error, Err} ->

--- a/src/riak_kv_wm_crdt.erl
+++ b/src/riak_kv_wm_crdt.erl
@@ -135,6 +135,7 @@
           rw,
           pr,
           pw,
+          node_confirms,
           basic_quorum,
           notfound_ok,
           include_context,
@@ -215,6 +216,7 @@ malformed_rw_params(RD, Ctx) ->
                        {#ctx.w,  "w",  "default"},
                        {#ctx.dw, "dw", "default"},
                        {#ctx.pw, "pw", "default"},
+                       {#ctx.node_confirms, "node_confirms", "default"},
                        {#ctx.pr, "pr", "default"}]),
     Res1 = lists:foldl(fun malformed_boolean_param/2,
                        Res,
@@ -478,7 +480,7 @@ handle_common_error(Reason, RD, Ctx) ->
                               Ctx};
         {n_val_violation, N} ->
             halt_with_message(400,
-                              "Specified w/dw/pw values invalid for bucket n "
+                              "Specified w/dw/pw/node_confirms values invalid for bucket n "
                               "value of ~p~n",[N], RD, Ctx);
         {r_val_unsatisfied, Requested, Returned} ->
             halt_with_message(503, "R-value unsatisfied: ~p/~p~n",
@@ -491,6 +493,9 @@ handle_common_error(Reason, RD, Ctx) ->
                               [Returned, Requested], RD, Ctx);
         {pw_val_unsatisfied, Requested, Returned} ->
             halt_with_message(503, "PW-value unsatisfied: ~p/~p~n",
+                              [Returned, Requested], RD, Ctx);
+        {node_confirms_val_unsatisfied, Requested, Returned} ->
+            halt_with_message(503, "node_confirms-value unsatisfied: ~p/~p~n",
                               [Returned, Requested], RD, Ctx);
         failed ->
             halt_with_message(412, "", RD, Ctx);
@@ -533,6 +538,7 @@ make_options(Ctx) ->
                {rw, Ctx#ctx.rw},
                {pr, Ctx#ctx.pr},
                {pw, Ctx#ctx.pw},
+               {node_confirms, Ctx#ctx.node_confirms},
                {basic_quorum, Ctx#ctx.basic_quorum},
                {notfound_ok, Ctx#ctx.notfound_ok},
                {timeout, Ctx#ctx.timeout},

--- a/test/ec_eqc.erl
+++ b/test/ec_eqc.erl
@@ -724,12 +724,8 @@ put_fsm_proc(ReqId, #params{n = N, w = W, dw = DW}) ->
     AllowMult = true,
     ReturnBody = false,
     NodeConfirms = 0,
-    NodeConfirmsfailthreshold = N-NodeConfirms+1,
     PutCore = riak_kv_put_core:init(N, W, DW, NodeConfirms,
                                     DW, %% SLF hack
-                                    N-W+1,   % cannot ever get W replies
-                                    NodeConfirmsfailthreshold,
-                                    N-DW+1,  % cannot ever get DW replies
                                     AllowMult,
                                     ReturnBody,
                                     [{Idx, primary, node1 } || Idx <- lists:seq(1, N)] %% SLF hack

--- a/test/put_fsm_eqc.erl
+++ b/test/put_fsm_eqc.erl
@@ -52,6 +52,7 @@
 -define(DEFAULT_BUCKET_PROPS,
         [{chash_keyfun, {riak_core_util, chash_std_keyfun}},
          {pw, 0},
+         {node_confirms, 0},
          {w, quorum},
          {dw, quorum}]).
 -define(HOOK_SAYS_NO, <<"the hook says no">>).


### PR DESCRIPTION
Rebase/clean-up of nhs-riak/riak_kv/pull/2
----
See doc/Node-Diversity.md for full details.

Briefly, some Riak deployments require that a write is on multiple
physical nodes before they're safe.

Given a good ring, using Primaries is one way to ensure this physical
diversity is to use `pw=2` (for example) to ensure two physical nodes
for the write. This has an availability cost. With 5 nodes and 2 nodes
down storing on 2 physical nodes is still very possible, but 2
primaries will leave a range of preflists unavailable to write. This
commit adds a bucket property and put option of `node_confirms` to the
declare the number of diverse physical node acks required for a write
to be successful. For the above example `node_confirms=2` would be
used, and as long as any two diverse nodes (primary OR fallback)
reply, the write is a success.

See also:
nhs-riak/riak_core#1
nhs-riak/riak_test#1
  