### PR TITLE
Add `node_confirms` to PB API

### DIFF
--- a/src/riak_kv_pb_crdt.erl
+++ b/src/riak_kv_pb_crdt.erl
@@ -211,13 +211,16 @@ make_options(#dtfetchreq{r=R0, pr=PR0,
         make_option(n_val, NVal);
 make_options(#dtupdatereq{w=W0, dw=DW0, pw=PW0,
                           timeout=Timeout, sloppy_quorum=SloppyQ,
+                          node_confirms=NodeConfirms0,
                           n_val=NVal, return_body=RetVal}) ->
     W = decode_quorum(W0),
     DW = decode_quorum(DW0),
     PW = decode_quorum(PW0),
+    NodeConfirms = decode_quorum(NodeConfirms0),
     make_option(w, W) ++
         make_option(dw, DW) ++
         make_option(pw, PW) ++
+        make_option(node_confirms, NodeConfirms) ++
         make_option(timeout, timeout(Timeout)) ++
         make_option(sloppy_quorum, SloppyQ) ++
         make_option(n_val, NVal) ++ return_value(RetVal).

--- a/src/riak_kv_pb_object.erl
+++ b/src/riak_kv_pb_object.erl
@@ -217,6 +217,7 @@ process(#rpbputreq{bucket=B0, type=T, key=K, vclock=PbVC, content=RpbContent,
                    w=W0, dw=DW0, pw=PW0, return_body=ReturnBody,
                    return_head=ReturnHead, timeout=Timeout, asis=AsIs,
                    n_val=N_val, sloppy_quorum=SloppyQuorum,
+                   node_confirms=NodeConfirms0,
                    if_none_match=NoneMatch},
         #state{client=C} = State) ->
 
@@ -238,6 +239,7 @@ process(#rpbputreq{bucket=B0, type=T, key=K, vclock=PbVC, content=RpbContent,
     W = decode_quorum(W0),
     DW = decode_quorum(DW0),
     PW = decode_quorum(PW0),
+    NodeConfirms = decode_quorum(NodeConfirms0),
     B = maybe_bucket_type(T, B0),
     Options = case ReturnBody of
                   1 -> [returnbody];
@@ -254,7 +256,8 @@ process(#rpbputreq{bucket=B0, type=T, key=K, vclock=PbVC, content=RpbContent,
                    _ ->
                        Options
                end,
-    case C:put(O, make_options([{w, W}, {dw, DW}, {pw, PW}, 
+    case C:put(O, make_options([{w, W}, {dw, DW}, {pw, PW},
+                                {node_confirms, NodeConfirms},
                                 {timeout, Timeout}, {asis, AsIs},
                                 {n_val, N_val},
                                 {sloppy_quorum, SloppyQuorum}]) ++ Options2) of


### PR DESCRIPTION
objects/counters/datatypes all.

NOTE: depends on changes to `riak_pb` (will ref from that PR.)