### PR TITLE
Merge typed defaults if prop not present

### DIFF
--- a/src/riak_kv_util.erl
+++ b/src/riak_kv_util.erl
@@ -135,8 +135,21 @@ make_request(Request, Index) ->
 get_bucket_option(Type, BucketProps) ->
     case lists:keyfind(Type, 1, BucketProps) of
         {Type, Val} -> Val;
-        _ -> throw(unknown_bucket_option)
+        _ ->
+            get_default_bucket_option(Type)
     end.
+
+get_default_bucket_option(Type) ->
+    %% NOTE: the call to _type_ is because only bucket types don't
+    %% automagically inherit new properties added to riak_kv
+    %% https://github.com/nhs-riak/riak_kv/issues/9
+    case lists:keyfind(Type, 1, riak_core_bucket_type:defaults()) of
+        {Type, Val} ->
+            Val;
+        _ ->
+            throw({unknown_bucket_option, Type})
+    end.
+
 
 expand_value(Type, default, BucketProps) ->
     get_bucket_option(Type, BucketProps);


### PR DESCRIPTION
See nhs-riak/riak_kv#9
Typed buckets do not automatically inherit newly added default
properties (old-skool default buckets do thanks to the existence of
bucket fixups.)

As per the bug report, when PUTing to a Typed bucket after upgrade to
2.2.5 the call to riak_kv_util:expand_rw_value/4 throws if the
property `node_confirms` is not in the bucket properties, and for a
typed bucket created and activated before upgrade it won't be.

This is somewhat contentious. Ex-Basho @seancribbs has pointed out
that there is a reason for that throw, and that all nodes should agree
on the value, and misconfiguration can be an issue here.  There are
perhpas more complexities (we're retroactivley adding a reserved word,
for example.) Caveats in docs and probability should guard against
that latter though.

Given that the reasons not to do this are lost to time, and the
alternatives unpleasant, I'm content that this is a reasonable way for
typed buckets to inherit **NEW** properties added as defaults after
typed bucket creation.

There is an associated riak_core commit https://github.com/nhs-riak/riak_core/pull/8
There is a riak_test https://github.com/nhs-riak/riak_test/pull/5